### PR TITLE
IDX Widgets not protocol specific

### DIFF
--- a/idx/widgets/idx-widget-class.php
+++ b/idx/widgets/idx-widget-class.php
@@ -58,13 +58,15 @@ class Idx_Widget_Class extends \WP_Widget
 
         //only load leaflet scripts and styles for map search widget. WP takes care of duplicates automatically
         if (strpos($this->widget_url, 'mapwidgetjs.php')) {
-            wp_enqueue_script('custom-scriptLeaf', '//idxdyncdn.idxbroker.com/graphical/javascript/leaflet.js', __FILE__);
-            wp_enqueue_script('custom-scriptMQ', '//www.mapquestapi.com/sdk/leaflet/v1.0/mq-map.js?key=Gmjtd%7Cluub2h0rn0%2Crx%3Do5-lz1nh', __FILE__);
             wp_enqueue_style('cssLeaf', '//idxdyncdn.idxbroker.com/graphical/css/leaflet-1.000.css');
-            echo $after_title . "<script src=\"{$this->widget_url}\" defer></script>" . $after_widget;
+            wp_enqueue_script('custom-scriptLeaf', '//idxdyncdn.idxbroker.com/graphical/javascript/leaflet.js', __FILE__);
+            wp_enqueue_script('custom-scriptMQ', 'https://www.mapquestapi.com/sdk/leaflet/v1.0/mq-map.js?key=Gmjtd%7Cluub2h0rn0%2Crx%3Do5-lz1nh', __FILE__);
+            echo $after_title;
+            echo "<script src='" . str_replace( 'http://', '//', "{$this->widget_url}") ."' async defer></script>";
+            echo $after_widget;
         } else {
             echo $after_title;
-            echo "<script src='{$this->widget_url}'></script>";
+            echo "<script src='" . str_replace( 'http://', '//', "{$this->widget_url}") ."' async defer></script>";
             echo $after_widget;
         }
 


### PR DESCRIPTION
Let IDX Widgets be not specific to a protocol. This means sites that have SSL support for IDX subdomains can use them. I also set widget to async and defer for better performance.