### PR TITLE
Remove NoIndex

### DIFF
--- a/idx/initiate-plugin.php
+++ b/idx/initiate-plugin.php
@@ -142,12 +142,6 @@ class Initiate_Plugin
         echo "\n<!-- IDX Broker WordPress Plugin " . \Idx_Broker_Plugin::IDX_WP_PLUGIN_VERSION . " Activated -->\n";
 
         echo "<!-- IDX Broker WordPress Plugin Wrapper Meta-->\n\n";
-        global $post;
-        //If wrapper, add noindex tag which is stripped out by our system
-        if ($post && $post->post_type === 'idx-wrapper') {
-            // If html is being modified we offer filters for developers to modify this tag as needed.
-            echo apply_filters( 'idx_activation_meta_tags', "<meta name='idx-robot'>\n<meta name='robots' content='noindex,nofollow'>\n");
-        }
     }
 
     public function idx_broker_platinum_plugin_actlinks($links)


### PR DESCRIPTION
There are too many cases of other plugins that minify wrappers or perform other modifications that breaks IDX Broker from finding and removing the noindex tag for Wrappers. In this pull request I just removed the noindex meta tag, as its much better to have all idx pages indexed including the wrappers vs not indexing to just hide the wrapper from search results.